### PR TITLE
Download nltk stopwords corpus

### DIFF
--- a/App.py
+++ b/App.py
@@ -28,7 +28,6 @@ import pandas as pd
 import base64,random
 import time,datetime
 #libraries to parse the resume pdf files
-from pyresparser import ResumeParser
 from pdfminer3.layout import LAParams, LTTextBox
 from pdfminer3.pdfpage import PDFPage
 from pdfminer3.pdfinterp import PDFResourceManager
@@ -41,8 +40,19 @@ import pymysql
 from Courses import ds_course,web_course,android_course,ios_course,uiux_course,resume_videos,interview_videos
 import pafy #for uploading youtube videos
 import plotly.express as px #to create visualisations at the admin session
+import os
 import nltk
-nltk.download('stopwords')
+
+# Ensure required NLTK data is available before importing pyresparser
+nltk_data_dir = os.path.join(os.path.dirname(__file__), "nltk_data")
+if nltk_data_dir not in nltk.data.path:
+    nltk.data.path.append(nltk_data_dir)
+try:
+    nltk.data.find("corpora/stopwords")
+except LookupError:
+    nltk.download("stopwords", download_dir=nltk_data_dir, quiet=True)
+
+from pyresparser import ResumeParser
 
 
 def fetch_yt_video(link):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ plotly
 pymysql
 streamlit-tags
 Pillow
+nltk


### PR DESCRIPTION
Ensures NLTK stopwords are downloaded before `pyresparser` import to resolve `LookupError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a70c2e05-1ded-4b67-bc99-3d5d8b7ab306">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a70c2e05-1ded-4b67-bc99-3d5d8b7ab306">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

